### PR TITLE
VibranceSetting Ingame value

### DIFF
--- a/vibrance.GUI/NVIDIA/NvidiaVibranceGUI.cs
+++ b/vibrance.GUI/NVIDIA/NvidiaVibranceGUI.cs
@@ -432,7 +432,8 @@ namespace vibrance.GUI
             ListViewItem selectedItem = this.listApplications.SelectedItems[0];
             if (selectedItem != null)
             {
-                VibranceSettings settingsWindow = new VibranceSettings(v, settingsBackgroundWorker, selectedItem);
+                NvidiaApplicationSetting actualSetting = applicationSettings.FirstOrDefault(x => x.FileName == selectedItem.Tag.ToString());
+                VibranceSettings settingsWindow = new VibranceSettings(v, settingsBackgroundWorker, selectedItem, actualSetting);
                 DialogResult result = settingsWindow.ShowDialog();
                 if (result == DialogResult.OK)
                 {

--- a/vibrance.GUI/NVIDIA/VibranceSettings.cs
+++ b/vibrance.GUI/NVIDIA/VibranceSettings.cs
@@ -15,8 +15,9 @@ namespace vibrance.GUI.NVIDIA
         private BackgroundWorker settingsBackgroundWorker;
         private IVibranceProxy v;
         private ListViewItem sender;
+        private SettingsController settingsController;
 
-        public VibranceSettings(IVibranceProxy v, BackgroundWorker settingsBackgroundWorker, ListViewItem sender)
+        public VibranceSettings(IVibranceProxy v, BackgroundWorker settingsBackgroundWorker, ListViewItem sender, NvidiaApplicationSetting setting)
         {
             InitializeComponent();
             this.settingsBackgroundWorker = settingsBackgroundWorker;
@@ -24,6 +25,14 @@ namespace vibrance.GUI.NVIDIA
             this.v = v;
             this.labelTitle.Text += "\"" + sender.Text + "\"";
             this.pictureBox.Image = this.sender.ListView.LargeImageList.Images[this.sender.ImageIndex];
+            // If the setting is new, we don't need to set the progress bar value
+            if (setting != null)
+            {
+                // Sets the progress bar value to the Ingame Vibrance setting
+                this.trackBarIngameLevel.Value = setting.IngameLevel;
+                // Necessary to reload the label which tells the percentage
+                trackBarIngameLevel_Scroll(null, null); 
+            }
         }
 
         private void trackBarIngameLevel_Scroll(object sender, EventArgs e)

--- a/vibrance.GUI/NVIDIA/VibranceSettings.cs
+++ b/vibrance.GUI/NVIDIA/VibranceSettings.cs
@@ -15,7 +15,6 @@ namespace vibrance.GUI.NVIDIA
         private BackgroundWorker settingsBackgroundWorker;
         private IVibranceProxy v;
         private ListViewItem sender;
-        private SettingsController settingsController;
 
         public VibranceSettings(IVibranceProxy v, BackgroundWorker settingsBackgroundWorker, ListViewItem sender, NvidiaApplicationSetting setting)
         {


### PR DESCRIPTION
VibranceSetting progress bar now automatically sets its value to the
saved one
![image](https://cloud.githubusercontent.com/assets/6270283/8932574/4642da56-353e-11e5-9a7f-bf60f01aefde.png)

When user tried to edit a program setting before, the progress bar value was always 50%. Now it's fixed.