### PR TITLE
This resolves #39 - "Vibrance does not reset to "Windows Vibrance Lev…

### DIFF
--- a/vibrance.GUI/common/VibranceGUI.cs
+++ b/vibrance.GUI/common/VibranceGUI.cs
@@ -296,6 +296,7 @@ namespace vibrance.GUI.common
                 this.Update();
                 if (_v != null && _v.GetVibranceInfo().isInitialized)
                 {
+                    _v.HandleDvcExit();
                     _v.SetShouldRun(false);
                     _v.UnloadLibraryEx();
                 }


### PR DESCRIPTION
…el" when VibranceGUI is exited."

o added HandleDvcExit(IVibranceProxy) to CleanUp()