### PR TITLE
Added exception handling for closing processes and changed ProcessExplorer reload

### DIFF
--- a/vibrance.GUI/common/ProcessExplorer.cs
+++ b/vibrance.GUI/common/ProcessExplorer.cs
@@ -102,9 +102,9 @@ namespace vibrance.GUI.common
 
         private void button_Click(object sender, EventArgs e)
         {
-            listView.Items.Clear();
             if (!backgroundWorker.IsBusy)
             {
+                listView.Items.Clear();
                 backgroundWorker.RunWorkerAsync();
             }
         }

--- a/vibrance.GUI/common/ProcessExplorer.cs
+++ b/vibrance.GUI/common/ProcessExplorer.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Management;
 using System.Text;
@@ -43,11 +44,10 @@ namespace vibrance.GUI.common
             {
                 if (process.MainWindowHandle != IntPtr.Zero && process.Id != Process.GetCurrentProcess().Id)
                 {
-                    string path = string.Empty;
                     try
                     {
-                        path = GetPathFromProcessId(process);
-                        if (path != string.Empty)
+                        string path = GetPathFromProcessId(process);
+                        if (path != string.Empty && File.Exists(path))
                         {
                             ProcessExplorerEntry processEntry = new ProcessExplorerEntry(path, Icon.ExtractAssociatedIcon(path), process);
                             backgroundWorker.ReportProgress(++activeApplicationCount, processEntry);

--- a/vibrance.GUI/common/WinEventHook.cs
+++ b/vibrance.GUI/common/WinEventHook.cs
@@ -239,15 +239,13 @@ namespace vibrance.GUI.common
                     GetInstance().DispatchWinEventHookEvent(e);
                 }
             }
-            catch (InvalidOperationException ex)
+            catch (InvalidOperationException)
             {
                 // The process property is not defined because the process has exited or it does not have an identifier.
-                VibranceGUI.Log(ex);
             }
-            catch (ArgumentException ex)
+            catch (ArgumentException)
             {
                 // The process specified by the processId parameter is not running.
-                VibranceGUI.Log(ex);
             }
         }
 


### PR DESCRIPTION
**Added exception handling for closing processes**
So there won't be exceptions e.g. when Windows is shutting down (the shutdown process can get interrupted by the error message box).

e.g.:
```
Exception Found:
Type: System.InvalidOperationException
Message: Die angeforderten Informationen sind nicht verfügbar, da der Prozess beendet wurde.
Source: System
Stacktrace:    bei System.Diagnostics.Process.EnsureState(State state)
   bei System.Diagnostics.Process.get_MainWindowHandle()
   bei System.Diagnostics.Process.get_MainWindowTitle()
   bei vibrance.GUI.common.WinEventHook.WinEventProc(IntPtr hWinEventHook, UInt32 eventType, IntPtr hwnd, Int32 idObject, Int32 idChild, UInt32 dwEventThread, UInt32 dwmsEventTime) in E:\Development\Repositories\vibranceGUI\vibrance.GUI\common\WinEventHook.cs:Zeile 242.
Exception String: System.InvalidOperationException: Die angeforderten Informationen sind nicht verfügbar, da der Prozess beendet wurde.
   bei System.Diagnostics.Process.EnsureState(State state)
   bei System.Diagnostics.Process.get_MainWindowHandle()
   bei System.Diagnostics.Process.get_MainWindowTitle()
   bei vibrance.GUI.common.WinEventHook.WinEventProc(IntPtr hWinEventHook, UInt32 eventType, IntPtr hwnd, Int32 idObject, Int32 idChild, UInt32 dwEventThread, UInt32 dwmsEventTime) in E:\Development\Repositories\vibranceGUI\vibrance.GUI\common\WinEventHook.cs:Zeile 242.
```

**Changed ProcessExplorer reload button to not clear list when busy**
So you won't get a splitted list when hitting the button too fast.